### PR TITLE
Fix restore ordering

### DIFF
--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -72,6 +72,7 @@ module ActiveSnapshot
       ActiveRecord::Base.transaction do
         ### Cache the child snapshots in a variable for re-use
         cached_snapshot_items = snapshot_items.includes(:item)
+        cached_snapshot_items = order_snapshot_items(cached_snapshot_items)
 
         existing_snapshot_children = item ? item.children_to_snapshot : []
 
@@ -108,6 +109,44 @@ module ActiveSnapshot
       end
 
       return true
+    end
+
+    private
+
+    def order_snapshot_items(items)
+      deps = {}
+      items_by_id = items.group_by(&:item_id)
+
+      items.each do |si|
+        deps[si] = []
+        klass = si.item_type.constantize
+        klass.reflect_on_all_associations(:belongs_to).each do |ref|
+          next if ref.options[:polymorphic]
+          parent_id = si.object[ref.foreign_key.to_s]
+          next unless parent_id
+          parents = items_by_id[parent_id]
+          next unless parents
+          parents.each do |candidate|
+            if candidate.item_type.constantize <= ref.klass
+              deps[si] << candidate
+            end
+          end
+        end
+      end
+
+      ordered = []
+      visited = {}
+
+      visit = lambda do |node|
+        return if visited[node]
+        visited[node] = true
+        deps[node].each { |d| visit.call(d) }
+        ordered << node
+      end
+
+      items.each { |si| visit.call(si) }
+
+      ordered
     end
 
     def fetch_reified_items(readonly: true)

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -209,6 +209,30 @@ class SnapshotTest < ActiveSupport::TestCase
     end
   end
 
+  def test_restore_respects_foreign_key_order
+    post = Post.create!(a: 5, b: 5)
+    comment = post.comments.create!(content: "foo")
+    snapshot = post.create_snapshot!(identifier: "fk-order")
+
+    comment.destroy!
+    post.destroy!
+
+    order = []
+
+    snapshot.snapshot_items.each do |si|
+      allow(si).to receive(:restore_item!).and_wrap_original do |m, *args|
+        order << si.item_type
+        m.call(*args)
+      end
+    end
+
+    snapshot.restore!
+
+    assert_equal ["Post", "Comment"], order.take(2)
+    assert Post.find_by(id: post.id)
+    assert_equal 1, Post.find(post.id).comments.count
+  end
+
   def test_single_model_snapshots_without_children
     instance = ParentWithoutChildren.create!({a: 1, b: 2})
 


### PR DESCRIPTION
## Summary
- restore snapshot items respecting belongs_to dependencies
- test restore order follows foreign key hierarchy

## Testing
- `bundle exec rake test` *(fails: Could not find gem 'minitest-reporters' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_684821c130ec83298e4546bf80cb74b1